### PR TITLE
Add example paths and Python script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,13 @@ Reverse Engineering of Pokémon Masters
 ### Usage:
 
 In `Program.cs`:
-- Change the path variables to point to your unpacked &amp; downloaded files. 
-- Specify the output path. 
+- Change the path variables to point to your unpacked & downloaded files.
+- Specify the output path.
+
+`dump_resources.py` contains a minimal Python reimplementation of the resource
+extraction loop. The default paths at the top of the script mirror those in
+`Program.cs`. This Python version does not implement ABND decryption or
+decompression and is provided purely as a starting point.
 
 When the Console project is run the program will decrypt, decompress, and export as much content as possible.
 

--- a/ReMastersConsole/Program.cs
+++ b/ReMastersConsole/Program.cs
@@ -15,11 +15,13 @@ namespace ReMastersConsole
 
             var paths = new GameDataPaths
             {
-                UnpackedAPKPath = @"E:\masters-inv\2.9.0\apk",
-                DownloadPath = @"E:\masters-inv\2.9.0\downloaded-resource-dir",
-                ShardPath = @"E:\masters-inv\2.9.0\downloaded-resource-dir\assetdb_shard",
+                // Default locations for a typical workflow. Adjust these
+                // if your files live elsewhere.
+                UnpackedAPKPath = @"E:\ReallyNeedHelp\PkmMaster\MastersEX",
+                DownloadPath = @"E:\ReallyNeedHelp\PkmMaster\Datamine256\Datamine",
+                ShardPath = @"E:\ReallyNeedHelp\PkmMaster\Datamine256\Datamine\assetdb_shard",
 
-                OutputPath = @"E:\masters-inv\2.9.0\dump",
+                OutputPath = @"E:\ReallyNeedHelp\PkmMaster\Datamine25600",
             };
 
             var settings = new DumpSettings(paths)

--- a/dump_resources.py
+++ b/dump_resources.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import logging
+from dataclasses import dataclass
+from typing import Dict
+
+# Default locations matching the C# console application.
+UNPACKED_APK_PATH = r"E:\ReallyNeedHelp\PkmMaster\MastersEX"
+DOWNLOAD_PATH = r"E:\ReallyNeedHelp\PkmMaster\Datamine256\Datamine"
+SHARD_PATH = r"E:\ReallyNeedHelp\PkmMaster\Datamine256\Datamine\assetdb_shard"
+OUTPUT_PATH = r"E:\ReallyNeedHelp\PkmMaster\Datamine25600"
+
+@dataclass
+class ResourceLocationEntry:
+    container_name: str
+
+class ABND:
+    def __init__(self, data: bytes):
+        self.data = data
+        # TODO: parse header, decrypt and decompress as needed
+
+    def dump(self, out_path: str):
+        """Placeholder for extracting the ABND archive."""
+        # In the original C# implementation this method iterates over
+        # all files inside the archive, decrypts and decompresses them
+        # and writes them to disk. Implementing the entire format is
+        # outside the scope of this example, so this function acts as
+        # a stub.
+        pass
+
+def dump_resources(resource_db: Dict[str, ResourceLocationEntry], download_path: str, out_root: str):
+    processed = set()
+
+    for entry in resource_db.values():
+        fn = entry.container_name
+        if fn in processed:
+            continue
+
+        folder = fn[0]
+        file_path = Path(download_path) / folder / fn
+
+        if not file_path.is_file():
+            logging.debug("Unable to find file (optional?): %s", fn)
+            continue
+
+        data = file_path.read_bytes()
+        abnd = ABND(data)
+
+        out_path = out_root
+        abnd.dump(out_path)
+
+        processed.add(fn)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    # In a real scenario the resource_db would be populated from the
+    # game's asset shard files. Here we just demonstrate the API with
+    # an empty dictionary because implementing ASDB parsing is beyond
+    # the scope of this example.
+    resource_db: Dict[str, ResourceLocationEntry] = {}
+
+    dump_resources(resource_db, DOWNLOAD_PATH, OUTPUT_PATH)


### PR DESCRIPTION
## Summary
- set example paths in `Program.cs`
- document Python script in README
- expose same default paths in `dump_resources.py` and provide a simple main block

## Testing
- `dotnet test` *(fails: `dotnet` not found)*